### PR TITLE
swap 画面で、通貨の入力とレート変換が反映できるように

### DIFF
--- a/src/components/ui/coin-select-view.tsx
+++ b/src/components/ui/coin-select-view.tsx
@@ -1,11 +1,10 @@
-import type { CoinTypes } from '@/types';
 import { useState } from 'react';
-import { coinList } from '@/data/static/coin-list';
+import { CoinType, coinList } from '@/data/static/coin-list';
 import { SearchIcon } from '@/components/icons/search';
 import { useModal } from '@/components/modal-views/context';
-
+import { CURRENCY_ID } from '@/constants';
 interface CoinSelectViewTypes {
-  onSelect: (selectedCoin: CoinTypes) => void;
+  onSelect: (currencyCode: CURRENCY_ID) => void;
 }
 
 export default function CoinSelectView({ onSelect }: CoinSelectViewTypes) {
@@ -21,16 +20,16 @@ export default function CoinSelectView({ onSelect }: CoinSelectViewTypes) {
       );
     });
   }
-  function handleSelectedCoin(item: CoinTypes) {
-    onSelect(item);
+  function handleSelectedCoin(item: CoinType) {
+    onSelect(item.id);
     closeModal();
   }
   function handleSelectedCoinOnKeyDown(
     event: React.KeyboardEvent<HTMLLIElement>,
-    item: CoinTypes
+    item: CoinType
   ) {
     if (event.code === 'Enter') {
-      onSelect(item);
+      onSelect(item.id);
       closeModal();
     }
   }
@@ -53,7 +52,7 @@ export default function CoinSelectView({ onSelect }: CoinSelectViewTypes) {
         {coinListData.length > 0 ? (
           coinListData.map((item, index) => (
             <li
-              key={item.code}
+              key={item.id}
               role="listitem"
               tabIndex={index}
               onClick={() => handleSelectedCoin(item)}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,30 @@
+export const CURRENCY_ID = {
+	USDT: 1,
+	USDC: 2,
+	BUSD: 3,
+	PB: 5,
+	DF: 4,
+} as const;
+
+export type CURRENCY_ID = typeof CURRENCY_ID[ keyof typeof CURRENCY_ID ];
+
+export const CURRENCY_CODE = {
+	[ CURRENCY_ID.USDT ]: 'USDT',
+	[ CURRENCY_ID.USDC ]: 'USDC',
+	[ CURRENCY_ID.BUSD ]: 'BUSD',
+	[ CURRENCY_ID.PB ]: 'PB',
+	[ CURRENCY_ID.DF ]: 'DF',
+} as const;
+
+export type CURRENCY_CODE = typeof CURRENCY_CODE[ keyof typeof CURRENCY_CODE ];
+
+// 1 DF = 0.1 USDT, 0.1 USDC, 0.1 BUSD
+// 1 PB = 0.1 USDT, 0.1 USDC, 0.1 BUSD
+export const EXCHANGE_RATE_VS_DF = {
+	[ CURRENCY_ID.USDT ]: 0.1,
+	[ CURRENCY_ID.USDC ]: 0.1,
+	[ CURRENCY_ID.BUSD ]: 0.1,
+	[ CURRENCY_ID.PB ]: 1,
+	[ CURRENCY_ID.DF ]: 1,
+} as const;
+

--- a/src/data/static/coin-list.tsx
+++ b/src/data/static/coin-list.tsx
@@ -1,20 +1,40 @@
-import { Bitcoin } from '@/components/icons/bitcoin';
-import { Ethereum } from '@/components/icons/ethereum';
 import { Tether } from '@/components/icons/tether';
 import { Bnb } from '@/components/icons/bnb';
 import { Usdc } from '@/components/icons/usdc';
-import { Cardano } from '@/components/icons/cardano';
 import { Doge } from '@/components/icons/doge';
+import { Doge as PB } from '@/components/icons/doge'; // TODO PB アイコン不明につき、仮で設置
+import { CURRENCY_ID } from '@/constants';
 
-export const coinList = [
+export type CoinType = {
+  id: CURRENCY_ID;
+  icon: JSX.Element;
+  name: string;
+};
+
+export const coinList: CoinType[] = [
   {
+    id: CURRENCY_ID.USDT,
     icon: <Tether />,
-    code: 'USDT',
     name: 'Tether USD',
   },
   {
+    id: CURRENCY_ID.USDC,
+    icon: <Usdc />,
+    name: 'USD Coin',
+  },
+  {
+    id: CURRENCY_ID.BUSD,
+    icon: <Bnb />,
+    name: 'Binance USD',
+  },
+  {
+    id: CURRENCY_ID.DF,
     icon: <Doge />,
-    code: 'DF',
     name: 'DF TOKEN',
+  },
+  {
+    id: CURRENCY_ID.PB,
+    icon: <PB />,
+    name: 'PB TOKEN',
   },
 ];


### PR DESCRIPTION
swap 画面で、通貨の入力とレート変換が反映できるようにしました。

PB のアイコンは、どれを使えばいいか不明だったため、仮で DF と同じものを使っています。

↓の動画にてご確認ください。
<video src="https://user-images.githubusercontent.com/212837/184072228-6b291579-364e-4a31-8e09-1ca14f3cfdcf.mp4"></video>

